### PR TITLE
Make cleaning optional and add missing cargo doc options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # cargo-docset changelog
 
-## Unpublished - v0.1.2
+## 9/5/2019 - v0.1.2
 
-* Feature: add --features, --no-default-features and --all-features options
-* Feature: add --frozen, --locked and --offline options
-* Enhancement: use cargo clean command instead of `remove\_dir\_all` to clean the rustdoc directory
-* Enhancement: better error output
+* Feature: add the following command line options mimicking `cargo doc`: --features, --no-default-features,
+  --all-features, --frozen, --locked, --offline, --lib, --bin and --bins.
+* Feature: make cleaning the doc directory optional, through `--no-clean` option.
+* Enhancement: use cargo clean command instead of `remove\_dir\_all` to clean the rustdoc directory.
+* Enhancement: better error output.
 
 ## 8/29/2019 - v0.1.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-docset"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cargo 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-docset"
 authors = ["R.Chavignat <r.chavignat@gmail.com>"]
 description = "Generates a Zeal/Dash docset for your rust package."
 edition = "2018"
-version = "0.1.1"
+version = "0.1.2"
 
 repository = "https://github.com/Robzz/cargo-docset"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -3,20 +3,21 @@
 [![Build Status](https://travis-ci.org/Robzz/cargo-docset.svg?branch=master)](https://travis-ci.org/Robzz/cargo-docset)
 [![Crate](https://img.shields.io/crates/v/cargo-docset.svg)](https://crates.io/crates/cargo-docset)
 
-`cargo-docset` is a tool enabling you to generate a [Dash](https://kapeli.com/dash)/[Zeal](https://zealdocs.org/)
+`cargo-docset` is a tool allowing you to generate a [Dash](https://kapeli.com/dash)/[Zeal](https://zealdocs.org/)
 compatible docset for your Rust packages and their dependencies.
 
 ## How to use
 
 Just run `cargo docset` in your crate's directory to generate the docset. It will be placed in the `target/docset`
-directory. There are a few options to select which package(s) will be documented, check the help message for details.
+directory. cargo-docset generally supports the same options as `cargo doc`, with a few additional ones. Run `cargo
+docset --help` for more information.
 
 To install your shiny new docset, copy it to your Zeal/Dash docset directory (available in the preferences, on Zeal at
 least) and restart Zeal/Dash.
 
 ## How it works
 
-Currently, `cargo-docset` runs `cargo` to generate the documentation, and then recursively walks the generated
+Currently, `cargo docset` runs `cargo` to generate the documentation, and then recursively walks the generated
 directory. The contents of every file is inferred from the file path, and cargo-docset then fills a SQLite database with
 the gathered information. The details of docset generation are available [here](https://kapeli.com/docsets#dashDocset).
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use cargo::{
     core::{compiler::CompileMode, Workspace},
-    ops::{clean, CleanOptions, doc, CompileOptions, DocOptions, Packages},
+    ops::{clean, CleanOptions, doc, CompileFilter, CompileOptions, DocOptions, FilterRule, LibRule, Packages},
     Config as CargoConfig
 };
 use rusqlite::{params, Connection};
@@ -30,7 +30,9 @@ pub struct GenerateConfig {
     pub no_default_features: bool,
     pub all_features: bool,
     pub exclude: Vec<String>,
-    pub clean: bool
+    pub clean: bool,
+    pub lib: bool,
+    pub bins: Option<Vec<String>>
 }
 
 impl Default for GenerateConfig {
@@ -43,7 +45,9 @@ impl Default for GenerateConfig {
             features: Vec::new(),
             no_default_features: true,
             all_features: false,
-            clean: true
+            clean: true,
+            lib: false,
+            bins: None
         }
     }
 }
@@ -260,6 +264,26 @@ pub fn generate(cargo_cfg: &CargoConfig, workspace: &Workspace, cfg: GenerateCon
     compile_opts.all_features = cfg.all_features;
     compile_opts.no_default_features = cfg.no_default_features;
     compile_opts.features = cfg.features;
+    if cfg.lib || cfg.bins.is_some() {
+        let bins_filter_rule =
+            if let Some(bins) = cfg.bins {
+                if bins.is_empty() {
+                    FilterRule::All
+                }
+                else {
+                    FilterRule::Just(bins)
+                }
+            }
+            else { FilterRule::Just(vec![]) };
+        compile_opts.filter = CompileFilter::Only {
+            all_targets: false,
+            lib: if cfg.lib { LibRule::True } else { LibRule::Default },
+            bins: bins_filter_rule,
+            examples: FilterRule::Just(vec![]),
+            tests: FilterRule::Just(vec![]),
+            benches: FilterRule::Just(vec![]),
+        }
+    }
     if cfg.doc_private_items {
         compile_opts.local_rustdoc_args = Some(vec!["--document-private-items".to_owned()]);
     }

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -29,7 +29,8 @@ pub struct GenerateConfig {
     pub features: Vec<String>,
     pub no_default_features: bool,
     pub all_features: bool,
-    pub exclude: Vec<String>
+    pub exclude: Vec<String>,
+    pub clean: bool
 }
 
 impl Default for GenerateConfig {
@@ -41,7 +42,8 @@ impl Default for GenerateConfig {
             exclude: Vec::new(),
             features: Vec::new(),
             no_default_features: true,
-            all_features: false
+            all_features: false,
+            clean: true
         }
     }
 }
@@ -312,10 +314,10 @@ pub fn generate(cargo_cfg: &CargoConfig, workspace: &Workspace, cfg: GenerateCon
     docset_root_dir.push("docset");
     docset_root_dir.push(format!("{}.docset", root_package_name));
 
-    // We must clear the doc dir first, as there may be doc generated from previous runs there that
-    // we don't want to pick up.
-    let clean_options = CleanOptions { config: &cargo_cfg, spec: vec![], target: None, release: false, doc: true };
-    clean(&workspace, &clean_options).context(CargoClean)?;
+    if cfg.clean {
+        let clean_options = CleanOptions { config: &cargo_cfg, spec: vec![], target: None, release: false, doc: true };
+        clean(&workspace, &clean_options).context(CargoClean)?;
+    }
     // Good to go, generate the documentation.
     let doc_cfg = DocOptions {
         open_result: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,15 @@ fn run(sub_matches: &ArgMatches) -> Result<()> {
     if sub_matches.is_present("no-clean") {
         cfg.clean = false;
     }
+    if sub_matches.is_present("lib") {
+        cfg.lib = true;
+    }
+    if sub_matches.is_present("bins") {
+        cfg.bins = Some(vec![])
+    }
+    else if sub_matches.is_present("bin") {
+        cfg.bins = sub_matches.values_of_lossy("bin");
+    }
 
     let cur_dir = current_dir().context(Cwd)?;
     let root_manifest = find_root_manifest_for_wd(&cur_dir).context(CargoConfig)?;
@@ -93,9 +102,16 @@ fn main() {
                 )
                 .arg(
                     Arg::from_usage(
-                        "-v, --verbose  'Enable verbose output (-vv for extra verbosity).'"
+                        "-v, --verbose  'Enable verbose output (-vv for extra verbosity)'"
                     )
                     .multiple(true)
+                )
+                .arg(
+                    Arg::from_usage(
+                        "--bin <BIN> 'Document only the specified binary'"
+                    )
+                    .multiple(true)
+                    .required(false)
                 )
                 .arg(
                     Arg::from_usage("--features <FEATURES> 'Space separated list of features to activate'")
@@ -105,7 +121,9 @@ fn main() {
                     "-q, --quiet             'Suppress all output to stdout.'
                     -C, --no-clean           'Do not clean the doc directory before generating the rustdoc'
                     --all                    'Document all packages in the workspace'
-                    --no-deps                'Dont build documentation for dependencies'
+                    --lib                    'Document only this package's library'
+                    --bins                   'Document all binaries'
+                    --no-deps                'Don't build documentation for dependencies'
                     --document-private-items 'Document private items'
                     --all-features           'Build with all features enabled'
                     --no-default-features    'Build without the 'default' feature'

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,9 @@ fn run(sub_matches: &ArgMatches) -> Result<()> {
     if sub_matches.is_present("features") {
         cfg.features = sub_matches.values_of_lossy("features").unwrap();
     }
+    if sub_matches.is_present("no-clean") {
+        cfg.clean = false;
+    }
 
     let cur_dir = current_dir().context(Cwd)?;
     let root_manifest = find_root_manifest_for_wd(&cur_dir).context(CargoConfig)?;
@@ -100,6 +103,7 @@ fn main() {
                 )
                 .args_from_usage(
                     "-q, --quiet             'Suppress all output to stdout.'
+                    -C, --no-clean           'Do not clean the doc directory before generating the rustdoc'
                     --all                    'Document all packages in the workspace'
                     --no-deps                'Dont build documentation for dependencies'
                     --document-private-items 'Document private items'


### PR DESCRIPTION
This adds the final missing cli options to mimic `cargo doc`, and provides a flag to make cleaning the doc directory optional if not required in the user's case.  
This also makes the changelog and cargo manifest ready for release :rocket: 

Closes #2 