### PR TITLE
Don't panic when invoked directly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ fn main() {
         .bin_name("cargo")
         .subcommand(
             SubCommand::with_name("docset")
+                .about("Generates a docset")
                 .arg(
                     Arg::from_usage("-p, --package <SPEC>...  'Package(s) to document'")
                         .required(false)
@@ -133,10 +134,15 @@ fn main() {
                 )
         )
         .get_matches();
-    let sub_matches = matches.subcommand_matches("docset").unwrap();
-
-    if let Err(e) = run(sub_matches) {
-        eprintln!("{}", e);
+    if let Some(sub_matches) = matches.subcommand_matches("docset") {
+        if let Err(e) = run(sub_matches) {
+            eprintln!("{}", e);
+            exit(1);
+        }
+    }
+    else {
+        println!("Invalid arguments.");
+        println!("{}", matches.usage());
         exit(1);
     }
 }


### PR DESCRIPTION
Don't panic when the app is invoked directly as `cargo-docset` and print the usage message instead.

For reference, the proper way to invoke the app directly without passing by cargo is `cargo-docset docset` to satistfy the CLI args parser.

Fixes #11