### PR TITLE
Allow external javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # cargo-docset changelog
 
+## 1/6/2020 - v0.1.4
+
+* Bugfix: enable external JavaScript in Info.plist, should fix docsets not rendering properly in Dash.
+
 ## 10/28/2019 - v0.1.3
 
 * Bugfix: don't crash the application when invoked directly as `cargo-docset`, print the usage message instead.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-docset"
 authors = ["R.Chavignat <r.chavignat@gmail.com>"]
 description = "Generates a Zeal/Dash docset for your rust package."
 edition = "2018"
-version = "0.1.3"
+version = "0.1.4"
 
 repository = "https://github.com/Robzz/cargo-docset"
 readme = "README.md"

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -2,13 +2,16 @@
 
 use crate::{
     common::{DocsetEntry, EntryType, Package},
-    error::*
+    error::*,
 };
 
 use cargo::{
     core::{compiler::CompileMode, Workspace},
-    ops::{clean, CleanOptions, doc, CompileFilter, CompileOptions, DocOptions, FilterRule, LibRule, Packages},
-    Config as CargoConfig
+    ops::{
+        clean, doc, CleanOptions, CompileFilter, CompileOptions, DocOptions, FilterRule, LibRule,
+        Packages,
+    },
+    Config as CargoConfig,
 };
 use rusqlite::{params, Connection};
 use snafu::ResultExt;
@@ -18,7 +21,7 @@ use std::{
     ffi::OsStr,
     fs::{copy, create_dir_all, read_dir, remove_dir_all, File},
     io::Write,
-    path::{Path, PathBuf}
+    path::{Path, PathBuf},
 };
 
 #[derive(Debug)]
@@ -32,7 +35,7 @@ pub struct GenerateConfig {
     pub exclude: Vec<String>,
     pub clean: bool,
     pub lib: bool,
-    pub bins: Option<Vec<String>>
+    pub bins: Option<Vec<String>>,
 }
 
 impl Default for GenerateConfig {
@@ -47,7 +50,7 @@ impl Default for GenerateConfig {
             all_features: false,
             clean: true,
             lib: false,
-            bins: None
+            bins: None,
         }
     }
 }
@@ -55,7 +58,7 @@ impl Default for GenerateConfig {
 fn parse_docset_entry<P1: AsRef<Path>, P2: AsRef<Path>>(
     module_path: &Option<&str>,
     rustdoc_root_dir: P1,
-    file_path: P2
+    file_path: P2,
 ) -> Option<DocsetEntry> {
     if file_path.as_ref().extension() == Some(OsStr::new("html")) {
         let file_name = file_path.as_ref().file_name().unwrap().to_string_lossy();
@@ -76,62 +79,62 @@ fn parse_docset_entry<P1: AsRef<Path>, P2: AsRef<Path>>(
                                 Some(DocsetEntry::new(
                                     format!("{}::{}", mod_path, parts[0]),
                                     EntryType::Module,
-                                    file_db_path
+                                    file_db_path,
                                 ))
                             } else {
                                 // Package entry
                                 Some(DocsetEntry::new(
                                     mod_path.to_string(),
                                     EntryType::Package,
-                                    file_db_path
+                                    file_db_path,
                                 ))
                             }
                         } else {
                             None
                         }
                     }
-                    _ => None
+                    _ => None,
                 }
             }
             3 => match parts[0] {
                 "const" => Some(DocsetEntry::new(
                     format!("{}::{}", module_path.unwrap().to_string(), parts[1]),
                     EntryType::Constant,
-                    file_db_path
+                    file_db_path,
                 )),
                 "enum" => Some(DocsetEntry::new(
                     format!("{}::{}", module_path.unwrap().to_string(), parts[1]),
                     EntryType::Enum,
-                    file_db_path
+                    file_db_path,
                 )),
                 "fn" => Some(DocsetEntry::new(
                     format!("{}::{}", module_path.unwrap().to_string(), parts[1]),
                     EntryType::Function,
-                    file_db_path
+                    file_db_path,
                 )),
                 "macro" => Some(DocsetEntry::new(
                     format!("{}::{}", module_path.unwrap().to_string(), parts[1]),
                     EntryType::Macro,
-                    file_db_path
+                    file_db_path,
                 )),
                 "trait" => Some(DocsetEntry::new(
                     format!("{}::{}", module_path.unwrap().to_string(), parts[1]),
                     EntryType::Trait,
-                    file_db_path
+                    file_db_path,
                 )),
                 "struct" => Some(DocsetEntry::new(
                     format!("{}::{}", module_path.unwrap().to_string(), parts[1]),
                     EntryType::Struct,
-                    file_db_path
+                    file_db_path,
                 )),
                 "type" => Some(DocsetEntry::new(
                     format!("{}::{}", module_path.unwrap().to_string(), parts[1]),
                     EntryType::Type,
-                    file_db_path
+                    file_db_path,
                 )),
-                _ => None
+                _ => None,
             },
-            _ => None
+            _ => None,
         }
     } else {
         None
@@ -143,7 +146,7 @@ const ROOT_SKIP_DIRS: &[&str] = &["src", "implementors"];
 fn recursive_walk(
     root_dir: &Path,
     cur_dir: &Path,
-    module_path: Option<&str>
+    module_path: Option<&str>,
 ) -> Result<Vec<DocsetEntry>> {
     let dir = read_dir(cur_dir).context(IoRead)?;
     let mut entries = vec![];
@@ -162,7 +165,7 @@ fn recursive_walk(
                 subdir_entries.push(recursive_walk(
                     &root_dir,
                     &dir_entry.path(),
-                    Some(&subdir_module_path)
+                    Some(&subdir_module_path),
                 ));
             }
         } else if let Some(entry) = parse_docset_entry(&module_path, &root_dir, &dir_entry.path()) {
@@ -185,7 +188,7 @@ fn generate_sqlite_index<P: AsRef<Path>>(docset_dir: P, entries: Vec<DocsetEntry
         "CREATE TABLE searchIndex(id INTEGER PRIMARY KEY, name TEXT, type TEXT, path TEXT);
         CREATE UNIQUE INDEX anchor ON searchIndex (name, type, path);
         )",
-        params![]
+        params![],
     )
     .context(Sqlite)?;
     let transaction = conn.transaction().context(Sqlite)?;
@@ -197,7 +200,7 @@ fn generate_sqlite_index<P: AsRef<Path>>(docset_dir: P, entries: Vec<DocsetEntry
             stmt.execute(&[
                 entry.name,
                 entry.ty.to_string(),
-                entry.path.to_str().unwrap().to_owned()
+                entry.path.to_str().unwrap().to_owned(),
             ])
             .context(Sqlite)?;
         }
@@ -260,26 +263,30 @@ pub fn generate(cargo_cfg: &CargoConfig, workspace: &Workspace, cfg: GenerateCon
     let mut compile_opts = CompileOptions::new(
         &cargo_cfg,
         CompileMode::Doc {
-            deps: !cfg.no_dependencies
-        }
-    ).context(CargoDoc)?;
+            deps: !cfg.no_dependencies,
+        },
+    )
+    .context(CargoDoc)?;
     compile_opts.all_features = cfg.all_features;
     compile_opts.no_default_features = cfg.no_default_features;
     compile_opts.features = cfg.features;
     if cfg.lib || cfg.bins.is_some() {
-        let bins_filter_rule =
-            if let Some(bins) = cfg.bins {
-                if bins.is_empty() {
-                    FilterRule::All
-                }
-                else {
-                    FilterRule::Just(bins)
-                }
+        let bins_filter_rule = if let Some(bins) = cfg.bins {
+            if bins.is_empty() {
+                FilterRule::All
+            } else {
+                FilterRule::Just(bins)
             }
-            else { FilterRule::Just(vec![]) };
+        } else {
+            FilterRule::Just(vec![])
+        };
         compile_opts.filter = CompileFilter::Only {
             all_targets: false,
-            lib: if cfg.lib { LibRule::True } else { LibRule::Default },
+            lib: if cfg.lib {
+                LibRule::True
+            } else {
+                LibRule::Default
+            },
             bins: bins_filter_rule,
             examples: FilterRule::Just(vec![]),
             tests: FilterRule::Just(vec![]),
@@ -328,7 +335,7 @@ pub fn generate(cargo_cfg: &CargoConfig, workspace: &Workspace, cfg: GenerateCon
     };
     if cfg.package != Package::All && !cfg.exclude.is_empty() {
         return Args {
-            msg: "--exclude must be used with --all"
+            msg: "--exclude must be used with --all",
         }
         .fail();
     }
@@ -341,13 +348,19 @@ pub fn generate(cargo_cfg: &CargoConfig, workspace: &Workspace, cfg: GenerateCon
     docset_root_dir.push(format!("{}.docset", root_package_name));
 
     if cfg.clean {
-        let clean_options = CleanOptions { config: &cargo_cfg, spec: vec![], target: None, release: false, doc: true };
+        let clean_options = CleanOptions {
+            config: &cargo_cfg,
+            spec: vec![],
+            target: None,
+            release: false,
+            doc: true,
+        };
         clean(&workspace, &clean_options).context(CargoClean)?;
     }
     // Good to go, generate the documentation.
     let doc_cfg = DocOptions {
         open_result: false,
-        compile_opts
+        compile_opts,
     };
     doc(&workspace, &doc_cfg).context(CargoDoc)?;
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -84,7 +84,7 @@ fn parse_docset_entry<P1: AsRef<Path>, P2: AsRef<Path>>(
                             } else {
                                 // Package entry
                                 Some(DocsetEntry::new(
-                                    mod_path.to_string(),
+                                    (*mod_path).to_string(),
                                     EntryType::Package,
                                     file_db_path,
                                 ))

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -245,6 +245,8 @@ fn write_metadata<P: AsRef<Path>>(docset_root_dir: P, package_name: &str) -> Res
                 <string>{}</string>
             <key>isDashDocset</key>
                 <true/>
+            <key>isJavaScriptEnabled</key>
+                <true/>
         </dict>
         </plist>",
          package_name, package_name, package_name, package_name).context(IoWrite)?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ pub enum Package {
     All,
     Current,
     Single(String),
-    List(Vec<String>)
+    List(Vec<String>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,7 +20,7 @@ pub enum EntryType {
     Package, // i.e. crate
     Struct,
     Trait,
-    Type //Union // Is this even implemented in Rust ?
+    Type, //Union // Is this even implemented in Rust ?
 }
 
 impl Display for EntryType {
@@ -34,7 +34,7 @@ impl Display for EntryType {
             EntryType::Package => write!(f, "Package"),
             EntryType::Struct => write!(f, "Struct"),
             EntryType::Trait => write!(f, "Trait"),
-            EntryType::Type => write!(f, "Type")
+            EntryType::Type => write!(f, "Type"),
         }
     }
 }
@@ -43,5 +43,5 @@ impl Display for EntryType {
 pub struct DocsetEntry {
     pub name: String,
     pub ty: EntryType,
-    pub path: PathBuf
+    pub path: PathBuf,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use snafu::Snafu;
 use std::{error::Error as StdError, result::Result as StdResult};
 
 pub struct FailureCompat {
-    e: FailureError
+    e: FailureError,
 }
 
 impl FailureCompat {
@@ -34,42 +34,42 @@ pub enum Error {
     #[snafu(display("Cargo error: {}", source))]
     Cargo {
         #[snafu(source(from(FailureError, FailureCompat::new)))]
-        source: FailureCompat
+        source: FailureCompat,
     },
     #[snafu(display("Cargo doc error: {}", source))]
     CargoDoc {
         #[snafu(source(from(FailureError, FailureCompat::new)))]
-        source: FailureCompat
+        source: FailureCompat,
     },
     #[snafu(display("Cargo configuration error: {}", source))]
     CargoConfig {
         #[snafu(source(from(FailureError, FailureCompat::new)))]
-        source: FailureCompat
+        source: FailureCompat,
     },
     #[snafu(display("Cargo clean error: {}", source))]
     CargoClean {
         #[snafu(source(from(FailureError, FailureCompat::new)))]
-        source: FailureCompat
+        source: FailureCompat,
     },
     #[snafu(display("Cannot determine the current directory: {}", source))]
     Cwd {
-        source: std::io::Error
+        source: std::io::Error,
     },
     #[snafu(display("I/O error: {}", source))]
     IoRead {
-        source: std::io::Error
+        source: std::io::Error,
     },
     #[snafu(display("I/O error: {}", source))]
     IoWrite {
-        source: std::io::Error
+        source: std::io::Error,
     },
     Sqlite {
-        source: rusqlite::Error
+        source: rusqlite::Error,
     },
     #[snafu(display("Invalid arguments: {}", msg))]
     Args {
-        msg: &'static str
-    }
+        msg: &'static str,
+    },
 }
 
 pub type Result<T> = StdResult<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use cargo::{
-    core::Workspace, util::important_paths::find_root_manifest_for_wd, Config as CargoCfg
+    core::Workspace, util::important_paths::find_root_manifest_for_wd, Config as CargoCfg,
 };
-use clap::{crate_authors, crate_version, App, ArgMatches, Arg, SubCommand};
+use clap::{crate_authors, crate_version, App, Arg, ArgMatches, SubCommand};
 use snafu::ResultExt;
 
 use std::env::current_dir;
@@ -26,16 +26,18 @@ fn run(sub_matches: &ArgMatches) -> Result<()> {
     }
 
     let mut cargo_cfg = CargoCfg::default().context(CargoConfig)?;
-    cargo_cfg.configure(
-        verbosity_level,
-        Some(quiet),
-        &None,
-        sub_matches.is_present("frozen"),
-        sub_matches.is_present("locked"),
-        sub_matches.is_present("offline"),
-        &None,
-        &[]
-    ).context(CargoConfig)?;
+    cargo_cfg
+        .configure(
+            verbosity_level,
+            Some(quiet),
+            &None,
+            sub_matches.is_present("frozen"),
+            sub_matches.is_present("locked"),
+            sub_matches.is_present("offline"),
+            &None,
+            &[],
+        )
+        .context(CargoConfig)?;
 
     let mut cfg = GenerateConfig::default();
     cfg.no_dependencies = sub_matches.is_present("no-deps");
@@ -69,8 +71,7 @@ fn run(sub_matches: &ArgMatches) -> Result<()> {
     }
     if sub_matches.is_present("bins") {
         cfg.bins = Some(vec![])
-    }
-    else if sub_matches.is_present("bin") {
+    } else if sub_matches.is_present("bin") {
         cfg.bins = sub_matches.values_of_lossy("bin");
     }
 
@@ -139,8 +140,7 @@ fn main() {
             eprintln!("{}", e);
             exit(1);
         }
-    }
-    else {
+    } else {
         println!("Invalid arguments.");
         println!("{}", matches.usage());
         exit(1);


### PR DESCRIPTION
This adds an entry in the `Info.plist` file to let Dash know to enable external JavaScript code. Fixes #14 

Additionally, the code was reformatted using `cargo fmt`.