### PR TITLE
Fix base directory detection and passing of the `--manifest-path` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # cargo-docset changelog
 
-## TBD - v0.2.1
+## 8/23/2020 - v0.2.1
 
+* Bugfix: fix spelling of the `manifest-path` when passed down to cargo.
 * Bugfix: fix detection of the workspace base directory for filesystem operations.
 * Documentation: mention the dependency on SQLite and link to rusqlite's documentation in the README.
 * Feature: provide the ability to use the SQLite version bundled with rusqlite through the `bundled-sqlite` feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## TBD - v0.2.1
 
+* Bugfix: fix detection of the workspace base directory for filesystem operations.
 * Documentation: mention the dependency on SQLite and link to rusqlite's documentation in the README.
 * Feature: provide the ability to use the SQLite version bundled with rusqlite through the `bundled-sqlite` feature.
 * Maintenance: update `rusqlite` to v0.24.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,11 +25,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-docset"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap 2.33.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -85,6 +87,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -155,9 +162,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
 version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "smallvec"
@@ -264,6 +299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 "checksum fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 "checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+"checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)" = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 "checksum libsqlite3-sys 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3a245984b1b06c291f46e27ebda9f369a94a1ab8461d0e845e23f9ced01f5db"
 "checksum linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
@@ -273,7 +309,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 "checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum rusqlite 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c78c3275d9d6eb684d2db4b2388546b32fdae0586c20a82f3905d21ea78b9ef"
+"checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 "checksum serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)" = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+"checksum serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)" = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+"checksum serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)" = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
 "checksum smallvec 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 "checksum snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7f5aed652511f5c9123cf2afbe9c244c29db6effa2abb05c866e965c82405ce"
 "checksum snafu-derive 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ebf8f7d5720104a9df0f7076a8682024e958bba0fe9848767bb44f251f3648e9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-docset"
 authors = ["R.Chavignat <r.chavignat@gmail.com>"]
 description = "Generates a Zeal/Dash docset for your rust package."
 edition = "2018"
-version = "0.2.0"
+version = "0.2.1"
 
 repository = "https://github.com/Robzz/cargo-docset"
 readme = "README.md"
@@ -23,5 +23,7 @@ default = []
 clap = "2.33"
 derive_more = "0.99"
 rusqlite = "0.24"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 snafu = "0.6"
 toml = "0.5"

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,7 +1,7 @@
 //! Implementation of the `generate` command.
 
 use crate::{
-    common::{DocsetEntry, EntryType, Package},
+    common::*,
     error::*
 };
 
@@ -14,7 +14,7 @@ use std::{
     ffi::OsStr,
     fs::{copy, create_dir_all, read_dir, remove_dir_all, File},
     io::{Read, Write},
-    path::{Path, PathBuf},
+    path::Path,
     process::Command
 };
 
@@ -328,7 +328,7 @@ pub fn generate(cfg: GenerateConfig) -> Result<()> {
             let mut manifest_file = File::open(
                 cfg.manifest_path
                     .clone()
-                    .unwrap_or_else(|| "Cargo.toml".to_owned())
+                    .unwrap_or(locate_package_manifest()?)
             )
             .context(IoRead)?;
             let mut manifest_contents = String::new();
@@ -350,8 +350,7 @@ pub fn generate(cfg: GenerateConfig) -> Result<()> {
                 .to_owned()
         }
     };
-    let mut docset_root_dir = PathBuf::new();
-    docset_root_dir.push("./");
+    let mut docset_root_dir = locate_workspace_root()?;
     docset_root_dir.push("target");
     let mut rustdoc_root_dir = docset_root_dir.clone();
     rustdoc_root_dir.push("doc");

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -363,7 +363,7 @@ pub fn generate(cfg: GenerateConfig) -> Result<()> {
         println!("Running 'cargo clean --doc'...");
         let mut cargo_clean_args = vec!["clean".to_owned()];
         if let Some(ref manifest_path) = &cfg.manifest_path {
-            cargo_clean_args.push("--manifest_path".to_owned());
+            cargo_clean_args.push("--manifest-path".to_owned());
             cargo_clean_args.push(manifest_path.to_owned());
         }
         let cargo_clean_result = Command::new("cargo")

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,11 +21,11 @@ pub enum Error {
     Cwd {
         source: std::io::Error
     },
-    #[snafu(display("I/O error: {}", source))]
+    #[snafu(display("I/O read error: {}", source))]
     IoRead {
         source: std::io::Error
     },
-    #[snafu(display("I/O error: {}", source))]
+    #[snafu(display("I/O write error: {}", source))]
     IoWrite {
         source: std::io::Error
     },
@@ -35,6 +35,9 @@ pub enum Error {
     },
     Sqlite {
         source: rusqlite::Error
+    },
+    Json {
+        source: serde_json::Error
     },
     #[snafu(display("Invalid arguments: {}", msg))]
     Args {


### PR DESCRIPTION
This fixes the workspace root directory detection and other directory shenanigans, like assuming we're in the root directory of a crate.

The `locate-project` cargo subcommand is used to locate the crate manifest, and the `metadata` subcommand is used to locate the workspace root.

Closes #20 