### PR TITLE
Support changing the target directory

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -14,8 +14,9 @@ use std::{
     ffi::OsStr,
     fs::{copy, create_dir_all, read_dir, remove_dir_all, File},
     io::{Read, Write},
-    path::Path,
-    process::Command
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr
 };
 
 #[derive(Debug)]
@@ -389,8 +390,8 @@ pub fn generate(cfg: GenerateConfig) -> Result<()> {
             }
         }
     };
-    let mut docset_root_dir = locate_workspace_root()?;
-    docset_root_dir.push("target");
+    let cargo_metadata = get_cargo_metadata()?;
+    let mut docset_root_dir = PathBuf::from_str(&cargo_metadata.target_directory).unwrap();
     let mut rustdoc_root_dir = docset_root_dir.clone();
     rustdoc_root_dir.push("doc");
     docset_root_dir.push("docset");

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,7 +9,6 @@ use std::{
     path::PathBuf,
     process::Command,
     result::Result as StdResult,
-    str::FromStr
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,12 +57,13 @@ pub struct DocsetEntry {
 
 #[derive(Debug, Deserialize)]
 struct ManifestLocation {
-    pub root: String
+    pub root: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct WorkspaceDir {
-    pub workspace_root: String
+pub struct CargoMetadata {
+    pub workspace_root: String,
+    pub target_directory: String,
 }
 
 pub fn locate_package_manifest() -> Result<String> {
@@ -76,12 +76,11 @@ pub fn locate_package_manifest() -> Result<String> {
     Ok(dir.root)
 }
 
-pub fn locate_workspace_root() -> Result<PathBuf> {
-    // Use the cargo `metadata` subcommand to locate the workspace root.
+pub fn get_cargo_metadata() -> Result<CargoMetadata> {
+    // Use the cargo `metadata` subcommand to locate the workspace root and other useful information.
     let cargo_locate_result = Command::new("cargo")
         .args(vec!["metadata", "--no-deps", "--format-version", "1"])
         .output()
         .context(Spawn)?;
-    let dir: WorkspaceDir = serde_json::from_slice(&cargo_locate_result.stdout).context(Json)?;
-    Ok(PathBuf::from_str(&dir.workspace_root).unwrap())
+    serde_json::from_slice::<CargoMetadata>(&cargo_locate_result.stdout).context(Json)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ fn run(sub_matches: &ArgMatches) -> Result<()> {
         all_features: sub_matches.is_present("all-features"),
         no_default_features: sub_matches.is_present("no-default-features"),
         target: sub_matches.value_of("target").map(String::from),
+        target_dir: sub_matches.value_of("target-dir").map(String::from),
         clean: !sub_matches.is_present("no-clean"),
         lib: sub_matches.is_present("lib"),
         bins: sub_matches.is_present("bins"),
@@ -100,6 +101,10 @@ fn main() {
                 )
                 .arg(
                     Arg::from_usage("--target <TRIPLE> 'Build for the specified target triple'")
+                        .required(false)
+                )
+                .arg(
+                    Arg::from_usage("--target-dir <PATH> 'Override the default target directory'")
                         .required(false)
                 )
                 .arg(


### PR DESCRIPTION
Add support for a `--target-dir` option to override the default target directory. If the option is not supplied, we use the cargo metadata command to retrieve the target directory location in order to respect the `CARGO_TARGET_DIR` environment variable or `build.target_dir` config value, and output the docset there.

Closes #24 