### PR TITLE
Update our own version in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-docset"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "atty",
  "cargo_metadata",


### PR DESCRIPTION
It seems that the crate's version wasn't updated in the Cargo.lock files. Setting it allows build tools to work if they expect the lockfile to remain frozen. I tested this with a nix build using `buildRustPackage`, and where the `master` branch failed to start a build (detecting that the .lock file isn't stable), this change does make it work.