### PR TITLE
Fix broken test

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,8 +282,6 @@ mod tests {
 
                     assert!(i >= 0, "Expected argument pair {:?} in arguments {:?}", pair, cargo_doc_args);
                 }
-
-                assert!(cargo_doc_args.is_empty());
             }
         }
     }


### PR DESCRIPTION
Not all options accepted by cargo-docset are passed down to cargo when running `cargo doc`, so that last assert does not make sense anymore.